### PR TITLE
feat: use leaflet layer control for map type

### DIFF
--- a/waypoints/index.html
+++ b/waypoints/index.html
@@ -21,6 +21,12 @@
             .map-container {
                 margin-bottom: 20px;
             }
+
+            /* Ensure Leaflet layer control icon renders correctly */
+            .leaflet-control-layers-toggle {
+                background-repeat: no-repeat;
+                background-size: 26px 26px;
+            }
             /* Style for waypoint labels */
             .waypoint-label {
                 background: transparent;
@@ -108,17 +114,6 @@
                     1px -1px 0 #fff,
                     -1px 1px 0 #fff,
                     1px 1px 0 #fff;
-            }
-            /* Map control style */
-            .map-type-control {
-                background: white;
-                padding: 5px 10px;
-                border-radius: 4px;
-                box-shadow: 0 1px 5px rgba(0,0,0,0.4);
-                cursor: pointer;
-            }
-            .map-type-control:hover {
-                background: #f4f4f4;
             }
             /* X marker style */
             .x-marker {

--- a/waypoints/js/map-init.js
+++ b/waypoints/js/map-init.js
@@ -30,38 +30,14 @@ function initializeMap() {
     // Add satellite layer to map by default
     satelliteLayer.addTo(map);
 
-    // Add a simple map type control
-    addMapTypeControl(satelliteLayer, streetLayer);
+    // Add Leaflet's built-in layer control for switching base maps
+    const baseLayers = {
+        Satellite: satelliteLayer,
+        "Street Map": streetLayer
+    };
+    L.control.layers(baseLayers, null, { position: 'topright' }).addTo(map);
 
     return map;
-}
-
-/**
- * Add a map type control to switch between satellite and street views
- * @param {L.TileLayer} satelliteLayer - The satellite map layer
- * @param {L.TileLayer} streetLayer - The street map layer
- */
-function addMapTypeControl(satelliteLayer, streetLayer) {
-    const mapTypeControl = L.control({position: 'topright'});
-
-    mapTypeControl.onAdd = function() {
-        const div = L.DomUtil.create('div', 'map-type-control');
-        div.innerHTML = 'Switch to Street Map';
-        div.onclick = function() {
-            if (map.hasLayer(satelliteLayer)) {
-                map.removeLayer(satelliteLayer);
-                map.addLayer(streetLayer);
-                div.innerHTML = 'Switch to Satellite Map';
-            } else {
-                map.removeLayer(streetLayer);
-                map.addLayer(satelliteLayer);
-                div.innerHTML = 'Switch to Street Map';
-            }
-        };
-        return div;
-    };
-
-    mapTypeControl.addTo(map);
 }
 
 // Export the functions and map reference


### PR DESCRIPTION
## Summary
- replace custom map type control with Leaflet's built-in layer control
- drop obsolete styles for old map switch button
- ensure layer control icon renders correctly without tiling

## Testing
- `npm test` *(fails: browsers missing; run `npx playwright install`)*

------
https://chatgpt.com/codex/tasks/task_e_68c59a4e02f8832a82ba3bf584be41a3